### PR TITLE
added methods to include additional default headers before preparing requests

### DIFF
--- a/pkg/nifi/client.go
+++ b/pkg/nifi/client.go
@@ -232,6 +232,22 @@ func (c *APIClient) ChangeBasePath(path string) {
 	c.cfg.BasePath = path
 }
 
+// Add default header to request
+func (c *APIClient) AddDefaultHeader(key string, value string) {
+	if key != "" && value != "" {
+		c.cfg.DefaultHeader[key] = value
+	}
+}
+
+// Add default header to request
+func (c *APIClient) RemoveDefaultHeader(key string) {
+	if key != "" {
+		if _, ok := c.cfg.DefaultHeader[key]; ok {
+			delete(c.cfg.DefaultHeader, key)
+		}
+	}
+}
+
 // prepareRequest build the request
 func (c *APIClient) prepareRequest(
 	ctx context.Context,

--- a/pkg/nifi/client.go
+++ b/pkg/nifi/client.go
@@ -239,7 +239,7 @@ func (c *APIClient) AddDefaultHeader(key string, value string) {
 	}
 }
 
-// Add default header to request
+// Remove default header
 func (c *APIClient) RemoveDefaultHeader(key string) {
 	if key != "" {
 		if _, ok := c.cfg.DefaultHeader[key]; ok {

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -187,6 +187,22 @@ func (c *APIClient) ChangeBasePath(path string) {
 	c.cfg.BasePath = path
 }
 
+// Add default header to request
+func (c *APIClient) AddDefaultHeader(key string, value string) {
+	if key != "" && value != "" {
+		c.cfg.DefaultHeader[key] = value
+	}
+}
+
+// Add default header to request
+func (c *APIClient) RemoveDefaultHeader(key string) {
+	if key != "" {
+		if _, ok := c.cfg.DefaultHeader[key]; ok {
+			delete(c.cfg.DefaultHeader, key)
+		}
+	}
+}
+
 // prepareRequest build the request
 func (c *APIClient) prepareRequest(
 	ctx context.Context,

--- a/pkg/registry/client.go
+++ b/pkg/registry/client.go
@@ -194,7 +194,7 @@ func (c *APIClient) AddDefaultHeader(key string, value string) {
 	}
 }
 
-// Add default header to request
+// Remove default header
 func (c *APIClient) RemoveDefaultHeader(key string) {
 	if key != "" {
 		if _, ok := c.cfg.DefaultHeader[key]; ok {

--- a/resources/client_gen/swagger_templates/client.mustache
+++ b/resources/client_gen/swagger_templates/client.mustache
@@ -164,7 +164,7 @@ func (c *APIClient) AddDefaultHeader(key string, value string) {
 	}
 }
 
-// Add default header to request
+// Remove default header
 func (c *APIClient) RemoveDefaultHeader(key string) {
 	if key != "" {
 		if _, ok := c.cfg.DefaultHeader[key]; ok {

--- a/resources/client_gen/swagger_templates/client.mustache
+++ b/resources/client_gen/swagger_templates/client.mustache
@@ -157,6 +157,22 @@ func (c *APIClient) ChangeBasePath(path string) {
 	c.cfg.BasePath = path
 }
 
+// Add default header to request
+func (c *APIClient) AddDefaultHeader(key string, value string) {
+	if key != "" && value != "" {
+		c.cfg.DefaultHeader[key] = value
+	}
+}
+
+// Add default header to request
+func (c *APIClient) RemoveDefaultHeader(key string) {
+	if key != "" {
+		if _, ok := c.cfg.DefaultHeader[key]; ok {
+			delete(c.cfg.DefaultHeader, key)
+		}
+	}
+}
+
 // prepareRequest build the request
 func (c *APIClient) prepareRequest(
 	ctx context.Context,


### PR DESCRIPTION
This just adds a couple of methods to set headers before the nigoapi client prepares requests.